### PR TITLE
Add support for Ammo Display #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [1.0.0-preview] - 2025-05-16
+## [1.0.0] - 2025-10-7
+
+Adding suppport for sending Ammo Count as device feedback.
+
+## [0.9.0] - 2025-05-16
 
 First release from stable branch.

--- a/Runtime/Lightguns/Devices/Blamcon/BlamconLightgunHID.cs
+++ b/Runtime/Lightguns/Devices/Blamcon/BlamconLightgunHID.cs
@@ -263,15 +263,38 @@ namespace Blamcon.Lightguns
                 Debug.LogError($"Failed to send command to {name}. Error: {result}");
             return result >= 0;
         }
-
-        /// <inheritdoc />
-        public bool EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true)
+        /// <summary>
+        /// Use to send ammo command to this specific device.
+        /// </summary>
+        /// <param name="command">The ammo command.</param>
+        public bool SendCommand(ref BlamconAmmoCommand command)
         {
-            var command = BlamconHIDOutputReport.Create(recoil, rumble, led);
             // Send the command to the device
             long result = ExecuteCommand(ref command);
             if (result < 0)
-                Debug.LogError($"Failed to send rumble command to {name}. Error: {result}");
+                Debug.LogError($"Failed to send command to {name}. Error: {result}");
+            return result >= 0;
+        }
+
+        /// <inheritdoc />
+        public bool EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true, bool ammo = false)
+        {
+            var command = BlamconHIDOutputReport.Create(recoil, rumble, led, ammo);
+            // Send the command to the device
+            long result = ExecuteCommand(ref command);
+            if (result < 0)
+                Debug.LogError($"Failed to send FFB control command to {name}. Error: {result}");
+            return result >= 0;
+        }
+        /// <inheritdoc />
+        public bool EnableAmmoFFBControl(bool ammo = true)
+        {
+            var command = BlamconHIDOutputReport.Create();
+            command.EnableAmmoFFBControl(ammo);
+            // Send the command to the device
+            long result = ExecuteCommand(ref command);
+            if (result < 0)
+                Debug.LogError($"Failed to send Ammo FFB control command to {name}. Error: {result}");
             return result >= 0;
         }
 
@@ -345,6 +368,18 @@ namespace Blamcon.Lightguns
             long result = ExecuteCommand(ref command);
             if (result < 0)
                 Debug.LogError($"Failed to send LED command to {name}. Error: {result}");
+            return result >= 0;
+        }
+        /// <inheritdoc />
+        public bool SendAmmoCount(int remaining)
+        {
+            var command = BlamconHIDOutputReport.Create();
+            command.SetAmmo(remaining);
+
+            // Send the command to the device
+            long result = ExecuteCommand(ref command);
+            if (result < 0)
+                Debug.LogError($"Failed to send Ammo count to {name}. Error: {result}");
             return result >= 0;
         }
 

--- a/Runtime/Lightguns/Devices/Blamcon/commands/BlamconAmmoCommand.cs
+++ b/Runtime/Lightguns/Devices/Blamcon/commands/BlamconAmmoCommand.cs
@@ -1,0 +1,44 @@
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
+using System.Runtime.InteropServices;
+using System;
+
+namespace Blamcon.Lightguns.LowLevel
+{
+    // BlamconAmmoCommand remains the same as it defines an output command.
+    // Ensure its size and offsets are correct for your device's output report.
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    public struct BlamconAmmoCommand : IBlamconCommand
+    {
+        public static FourCC Type => new FourCC('H', 'I', 'D', 'O');
+
+        // The size of bytes here needs to match the largest output report accepted by the device?
+        internal const int kSize = InputDeviceCommand.BaseCommandSize + 40;
+        internal const int kReportId = 0x23; // Must match the device's output report ID
+
+        [FieldOffset(0)] public InputDeviceCommand baseCommand;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public byte enableFFBControl;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 2)] public byte ammoRemaining;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 3)] public byte ammoUsed;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 4)] public byte ammoMax;
+
+        public FourCC typeStatic => Type;
+        public void EnableFFBControl(bool enable = true)
+        {
+            enableFFBControl = enable ? (byte)3 : (byte)2;
+        }
+        public void SetAmmo(int remaining) {
+            ammoRemaining = (byte)remaining;
+        }
+        public static BlamconAmmoCommand Create(int remaining) // Removed size param if it's fixed
+        {
+            return new BlamconAmmoCommand
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize), // Use kSize
+                reportId = kReportId,
+                ammoRemaining = (byte)remaining
+            };
+        }
+    }
+}

--- a/Runtime/Lightguns/Devices/Blamcon/commands/BlamconAmmoCommand.cs.meta
+++ b/Runtime/Lightguns/Devices/Blamcon/commands/BlamconAmmoCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e6c11ec06a83504d9fc62403d9e10ea

--- a/Runtime/Lightguns/Devices/Blamcon/commands/BlamconHIDOutputReport.cs
+++ b/Runtime/Lightguns/Devices/Blamcon/commands/BlamconHIDOutputReport.cs
@@ -26,14 +26,16 @@ namespace Blamcon.Lightguns.LowLevel
         [FieldOffset(0)] public InputDeviceCommand baseCommand;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
 
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public byte EnableRumbleUpdate;
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 2)] public byte EnableRumbleFFBControl;
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 3)] public byte EnableLedUpdate;
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 4)] public byte EnableLedFFBControl;
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 5)] public byte EnableRecoilUpdate;
-        [FieldOffset(InputDeviceCommand.BaseCommandSize + 6)] public byte EnableRecoilFFBControl;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public byte enableRumbleUpdate;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 2)] public byte enableRumbleFFBControl;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 3)] public byte enableLedUpdate;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 4)] public byte enableLedFFBControl;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 5)] public byte enableRecoilUpdate;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 6)] public byte enableRecoilFFBControl;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 7)] public byte enableAmmoUpdate;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 8)] public byte enableAmmoFFBControl;
 
-        // [FieldOffset(InputDeviceCommand.BaseCommandSize + 7)] public fixed byte pad1[8];
+        // [FieldOffset(InputDeviceCommand.BaseCommandSize + 9)] public fixed byte pad1[6];
 
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 15)] public byte rumble;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 16)] public short rumbleOnPeriod;
@@ -52,21 +54,31 @@ namespace Blamcon.Lightguns.LowLevel
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 30)] public byte recoilOnPeriod;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 31)] public byte recoilOffPeriod;
 
-        // [FieldOffset(InputDeviceCommand.BaseCommandSize + 32)] public fixed byte pad2[8];
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 32)] public byte ammoRemaining;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 33)] public byte ammoUsed;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 34)] public byte ammoMax;
+        // [FieldOffset(InputDeviceCommand.BaseCommandSize + 34)] public fixed byte pad2[5];
 
         public FourCC typeStatic => Type;
-        public void EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true)
+        public void EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true, bool ammo = true)
         {
-            EnableRecoilUpdate = 1;
-            EnableRecoilFFBControl = (recoil == true) ? (byte)3 : (byte)2;
-            EnableRumbleUpdate = 1;
-            EnableRumbleFFBControl = (rumble == true) ? (byte)3 : (byte)2;
-            EnableLedUpdate = 1;
-            EnableLedFFBControl = (led == true) ? (byte)3 : (byte)2;
+            enableRecoilUpdate = 1;
+            enableRecoilFFBControl = (recoil == true) ? (byte)3 : (byte)2;
+            enableRumbleUpdate = 1;
+            enableRumbleFFBControl = (rumble == true) ? (byte)3 : (byte)2;
+            enableLedUpdate = 1;
+            enableLedFFBControl = (led == true) ? (byte)3 : (byte)2;
+            enableAmmoUpdate = 1;
+            enableAmmoFFBControl = (ammo == true) ? (byte)3 : (byte)2;
+        }
+        public void EnableAmmoFFBControl(bool ammo = true)
+        {
+            enableAmmoUpdate = 1;
+            enableAmmoFFBControl = (ammo == true) ? (byte)3 : (byte)2;
         }
         public void SetRumble(int pulse)
         {
-            EnableRumbleUpdate = 1;
+            enableRumbleUpdate = 1;
             rumble = (byte)Math.Clamp(pulse, 0, 10);
         }
         public void SetRumble(int pulse, int on, int off)
@@ -77,7 +89,7 @@ namespace Blamcon.Lightguns.LowLevel
         }
         public void SetColor(int index, Color color)
         {
-            EnableLedUpdate = 1;
+            enableLedUpdate = 1;
             ledRed = (byte)Mathf.Clamp(color.r * 255, 0, 255);
             ledGreen = (byte)Mathf.Clamp(color.g * 255, 0, 255);
             ledBlue = (byte)Mathf.Clamp(color.b * 255, 0, 255);
@@ -95,13 +107,20 @@ namespace Blamcon.Lightguns.LowLevel
             ledFlashOffPeriod = (short)Math.Clamp(off, 40, 2000);
         }
         public void SetRecoil(int pulse) {
-            EnableRecoilUpdate = 1;
+            enableRecoilUpdate = 1;
             recoil = (byte)Math.Clamp(pulse, 0, 10);
         }
         public void SetRecoil(int pulse, int on, int off) {
             SetRecoil(pulse);
             recoilOnPeriod = (byte)Math.Clamp(on, 15, 255);
             recoilOffPeriod = (byte)Math.Clamp(off, 15, 255);
+        }
+        public void SetAmmo(int remaining)
+        {
+            enableAmmoUpdate = 1;
+            ammoRemaining = (byte)remaining;
+            ammoUsed = 0;
+            ammoMax = 0;
         }
         public static BlamconHIDOutputReport Create() // Removed size param if it's fixed
         {
@@ -111,18 +130,20 @@ namespace Blamcon.Lightguns.LowLevel
                 reportId = kReportId,
             };
         }
-        public static BlamconHIDOutputReport Create(bool recoil = true, bool rumble = true, bool led = true) // Removed size param if it's fixed
+        public static BlamconHIDOutputReport Create(bool recoil = true, bool rumble = true, bool led = true, bool ammo = true) // Removed size param if it's fixed
         {
             return new BlamconHIDOutputReport
             {
                 baseCommand = new InputDeviceCommand(Type, kSize), // Use kSize
                 reportId = kReportId,
-                EnableRecoilUpdate = 1,
-                EnableRecoilFFBControl = (recoil == true) ? (byte)3 : (byte)2,
-                EnableRumbleUpdate = 1,
-                EnableRumbleFFBControl = (rumble == true) ? (byte)3 : (byte)2,
-                EnableLedUpdate = 1,
-                EnableLedFFBControl = (led == true) ? (byte)3 : (byte)2
+                enableRecoilUpdate = 1,
+                enableRecoilFFBControl = (recoil == true) ? (byte)3 : (byte)2,
+                enableRumbleUpdate = 1,
+                enableRumbleFFBControl = (rumble == true) ? (byte)3 : (byte)2,
+                enableLedUpdate = 1,
+                enableLedFFBControl = (led == true) ? (byte)3 : (byte)2,
+                enableAmmoUpdate = 1,
+                enableAmmoFFBControl = (ammo == true) ? (byte)3 : (byte)2
             };
         }
     }

--- a/Runtime/Lightguns/Feedback/IForceFeedback.cs
+++ b/Runtime/Lightguns/Feedback/IForceFeedback.cs
@@ -22,7 +22,8 @@ namespace Blamcon.Lightguns
         /// is enabled the recoil will not fire when pulling the trigger, it will only recoil
         /// when the application gives the command.
         /// </remarks>
-        public bool EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true);
+        public bool EnableFFBControl(bool recoil = true, bool rumble = true, bool led = true, bool ammo = false);
+        public bool EnableAmmoFFBControl(bool ammo = true);
 
         /// <summary>
         /// Activate vibration motor on the device.
@@ -124,5 +125,18 @@ namespace Blamcon.Lightguns
         ///
         /// </remarks>
         public bool ActivateLED(int index, Color color, int flashes);
+        /// <summary>
+        /// Send Ammo Count to device.
+        /// </summary>
+        /// <value>Specify the amount of ammo remaining.</value>
+        /// <remarks>
+        /// An Ammo Count can be sent to the device mainly for the purpose of displaying. These displays
+        /// can take the form of a 2-digit seven segment led display or something more modern like OLED
+        /// screens. The count should represent the amount of ammo remaining to the current player. Send
+        /// ammo count when ammo changes in the game i.e. on start, on reload, on fire, etc.
+        ///
+        /// Returns a boolean to indicate if the IOCTL command was successful.
+        /// </remarks>
+        public bool SendAmmoCount(int remaining);
     }
 }

--- a/Samples~/LightgunRecoilCommand/LightgunTriggerAction.cs
+++ b/Samples~/LightgunRecoilCommand/LightgunTriggerAction.cs
@@ -101,6 +101,7 @@ namespace Samples.LightgunRecoilCommand
             {
                 // recoil once
                 device.ActivateRecoil(1);
+                device.SendAmmoCount(ammoLeft);
             }
         }
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.blamcon.lightguns",
   "displayName": "Blamcon Lightguns for Unity",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "unity": "6000.0",
   "description": "A new add-on that extends Unity's InputSystem to support Blamcon Lightguns.",
   "keywords": [


### PR DESCRIPTION
### Blamcon Unity Plugin for Lightguns #1 
This ticket will include the work to add support for ammo count. This will allow games to send a signal to the device with the remaining ammo count on events like stat, reload, fire, weapon switching, etc.
 
Changes necessary:
1. Update the HID Output Report
1. Add Ammo Counter functions
1. Update the BlamconLightgun device
